### PR TITLE
fix: improve error message for non-existent branches in checkout

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -55,6 +55,15 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 	worktreeName := fmt.Sprintf("%s-%s", repoName, sanitizedBranchName)
 	worktreePath := filepath.Join("..", worktreeName)
 
+	// Check if branch exists
+	exists, err := git.BranchExists(branch)
+	if err != nil {
+		return fmt.Errorf("failed to check branch existence: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("branch '%s' does not exist in the repository\nUse 'git branch -a' to see all available branches", branch)
+	}
+
 	// Create worktree
 	fmt.Printf("Creating worktree for branch '%s'...\n", branch)
 	if err := git.CreateWorktreeFromBranch(worktreePath, branch, branchName); err != nil {

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -64,3 +64,25 @@ func ListAllBranches() ([]string, error) {
 
 	return branches, nil
 }
+
+// BranchExists checks if a branch exists (local or remote)
+func BranchExists(branch string) (bool, error) {
+	// Check if it's a local branch
+	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", branch)
+	if err := cmd.Run(); err == nil {
+		return true, nil
+	}
+
+	// Check if it's a remote branch
+	remoteRef := branch
+	if !strings.HasPrefix(branch, "origin/") {
+		remoteRef = "origin/" + branch
+	}
+
+	cmd = exec.Command("git", "rev-parse", "--verify", "--quiet", remoteRef)
+	if err := cmd.Run(); err == nil {
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
## Summary
- Add clear error message when attempting to checkout a non-existent branch
- Suggest using `git branch -a` to see available branches
- Prevent confusing git error messages from being shown to users

## Changes
- Added `BranchExists` function to check if a branch exists locally or remotely
- Modified `gw checkout` command to validate branch existence before creating worktree
- Improved error message to be more user-friendly

## Test plan
- [x] Tested with non-existent branch: `gw checkout non-existent-branch-12345`
- [x] Verified error message shows: "branch 'non-existent-branch-12345' does not exist in the repository"
- [x] Verified existing branches still work correctly
- [x] All tests pass with `make check`

## Before
```
Creating worktree for branch 'feat/copy-env'...
fatal: invalid reference: feat/copy-env
Error: failed to create worktree: failed to create worktree: exit status 128
```

## After
```
Error: branch 'non-existent-branch-12345' does not exist in the repository
Use 'git branch -a' to see all available branches
```

🤖 Generated with [Claude Code](https://claude.ai/code)