### PR TITLE
Fix: Create worktrees relative to repository root directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored cmd package to use dependency injection pattern for better testability
 - Test coverage increased from ~20% to 71.2%
 
+### Fixed
+- Worktrees are now created relative to repository root directory, not current working directory
+
 ## [0.3.1] - 2025-07-31
 
 ### Fixed

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -28,12 +28,20 @@ func CreateWorktree(issueNumber, baseBranch string) (string, error) {
 		return "", err
 	}
 
-	// Create worktree directory name
-	worktreeDir := fmt.Sprintf("../%s-%s", repoName, issueNumber)
+	// Get repository root directory
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get repository root: %w", err)
+	}
+	repoRoot := strings.TrimSpace(string(output))
+
+	// Create worktree directory path relative to repository root
+	worktreeDir := filepath.Join(repoRoot, "..", fmt.Sprintf("%s-%s", repoName, issueNumber))
 	branchName := fmt.Sprintf("%s/impl", issueNumber)
 
 	// Create the worktree
-	cmd := exec.Command("git", "worktree", "add", worktreeDir, "-b", branchName, baseBranch)
+	cmd = exec.Command("git", "worktree", "add", worktreeDir, "-b", branchName, baseBranch)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -61,7 +69,16 @@ func RemoveWorktree(issueNumber string) error {
 		return err
 	}
 
-	worktreeDir := fmt.Sprintf("../%s-%s", repoName, issueNumber)
+	// Get repository root directory
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get repository root: %w", err)
+	}
+	repoRoot := strings.TrimSpace(string(output))
+
+	// Create worktree directory path relative to repository root
+	worktreeDir := filepath.Join(repoRoot, "..", fmt.Sprintf("%s-%s", repoName, issueNumber))
 	return RemoveWorktreeByPath(worktreeDir)
 }
 


### PR DESCRIPTION
## Summary
- Fixed worktree creation to always use repository root as the base path
- Ensures worktrees are created in the parent directory regardless of current working directory
- Updates both `CreateWorktree` and `RemoveWorktree` functions to use consistent path resolution

## Problem
Previously, when running `gw start` from a subdirectory, worktrees were created relative to the current directory (using `../`), which caused them to be created inside the repository instead of in the parent directory.

## Solution
Now using `git rev-parse --show-toplevel` to get the repository root directory and constructing the worktree path as `{repositoryRootDir}/../{targetDir}`.

## Test plan
- [x] Tested `gw start` from repository root - worktree created in parent directory
- [x] Tested `gw start` from subdirectory - worktree created in parent directory (not inside repo)
- [x] Tested `gw end` to remove worktrees - works correctly with new path resolution
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)