### PR TITLE
fix: update golangci/golangci-lint-action to use v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         args: --timeout=5m


### PR DESCRIPTION
[`golangci/golangci-lint-action@v3`](https://github.com/golangci/golangci-lint-action/tree/v3) hasn't been updated in two years and even though [it passes Lint](https://github.com/sotarok/gw/actions/runs/16969636704/job/48102810322#step:4:29), it always output deprecated errors.

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.64.8-linux-amd64/golangci-lint run --out-format=github-actions --timeout=5m] in [] ...
  level=warning msg="[config_reader] The output format `github-actions` is deprecated, please use `colored-line-number`"
  
  golangci-lint found no issues
  Ran golangci-lint in 13930ms
```