### PR TITLE
fix: Resolve original repository name when creating worktree from within a worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fix `gw start` creating incorrectly named worktree directories when run from within a worktree
+  - Previously running `gw start 456` from within `gw-123` worktree would create `gw-123-456`
+  - Now always creates `{original-repo}-{issue}` regardless of current directory (e.g., `gw-456`)
+  - Uses `git rev-parse --git-common-dir` to resolve the original repository name
 - Fix `gw start` failing when base branch exists only on remote (not locally)
   - Now automatically resolves `origin/<branch>` when the specified base branch doesn't exist locally but exists on remote
   - Allows using fetched remote branches without needing to create local tracking branches first

--- a/internal/git/env.go
+++ b/internal/git/env.go
@@ -24,7 +24,7 @@ func FindUntrackedEnvFiles(repoPath string) ([]EnvFile, error) {
 		}
 
 		// Skip .git directory
-		if info.IsDir() && info.Name() == ".git" {
+		if info.IsDir() && info.Name() == gitDir {
 			return filepath.SkipDir
 		}
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -66,7 +66,7 @@ func CreateWorktree(issueNumberOrBranch, baseBranch string) (string, error) {
 		return "", fmt.Errorf("not in a git repository")
 	}
 
-	repoName, err := GetRepositoryName()
+	repoName, err := GetOriginalRepositoryName()
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +112,7 @@ func RemoveWorktree(issueNumberOrBranch string) error {
 		return fmt.Errorf("not in a git repository")
 	}
 
-	repoName, err := GetRepositoryName()
+	repoName, err := GetOriginalRepositoryName()
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func ListWorktrees() ([]WorktreeInfo, error) {
 
 // GetWorktreeForIssue finds a worktree for a specific issue number or branch name
 func GetWorktreeForIssue(issueNumberOrBranch string) (*WorktreeInfo, error) {
-	repoName, err := GetRepositoryName()
+	repoName, err := GetOriginalRepositoryName()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Fix `gw start` creating incorrectly named worktree directories when run from within a worktree
- Previously running `gw start 456` from within `gw-123` worktree would create `gw-123-456`
- Now always creates `{original-repo}-{issue}` regardless of current directory (e.g., `gw-456`)

## Changes
- Add `GetOriginalRepositoryName()` function using `git rev-parse --git-common-dir`
- Update `CreateWorktree()`, `RemoveWorktree()`, `GetWorktreeForIssue()` to use the new function
- Add `gitDir` constant to fix lint warnings

## Test plan
- [x] Added unit test `TestGetOriginalRepositoryName` that creates a worktree and verifies the function returns the original repo name
- [x] All existing tests pass
- [x] `make check` passes (lint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)