### PR TITLE
feat: Add post-hook support for start and checkout commands

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,10 +35,16 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          use_sticky_comment: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Read the PR discussion to see what previous comments and suggestions have been made.
+            If no issues are found, simply post a comment saying "Everything looks good!" and stop here. Your work is done.
+            Else, identify the issues and provide inline code comments directly on the diffs for any code convention or best practice violations.
 
             Please review this pull request and provide feedback on:
             - Code quality and best practices
@@ -47,9 +53,17 @@ jobs:
             - Security concerns
             - Test coverage
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Rules and Guidelines:
+            - Use inline feedback where possible with specific line references.
+            - Summarize your overall feedback at the end of your response (it will be posted as a sticky comment automatically).
+            - Include code snippets in markdown format when discussing issues
+            - Default towards multi-line comments that show context around the issue
+            - Make sure that suggested improvements aren't already implemented in the PR by comparing old and new versions
+            - Before commenting, check the PR discussion and make sure you, or another user, haven't already made a similar comment or raised the same concern.
+            - Before commenting, check that the specific issue wasn't already addressed in a previous review iteration
+            - If you see the same issue multiple times, consolidate your feedback into a single comment that references all occurrences, rather than making separate     comments.
+            - Refer back to these rules and guidelines before you make comments.
+            - Never ask for user confirmation. Never wait for user messages.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Post-hook support for `start` and `checkout` commands (idea thanks to @pnikonowicz in #20)
+  - `post_start_hook` and `post_checkout_hook` configuration options in `.gwrc`
+  - Hook commands are executed via `sh -c` with environment variables: `GW_WORKTREE_PATH`, `GW_BRANCH_NAME`, `GW_REPO_NAME`, `GW_COMMAND`
+  - Enables integration with tmux, iTerm2, or any custom workflow
+  - Hook failures are treated as warnings and do not block command execution
+  - Example hook scripts for tmux and iTerm2 included in `examples/hooks/`
+
 ## [0.6.4] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -175,12 +175,76 @@ The interactive config editor allows you to:
 
 - **auto_cd**: Automatically change to the new worktree directory after creation (default: true)
 - **update_iterm2_tab**: Update iTerm2 tab name when creating/switching/removing worktrees (default: false)
+- **post_start_hook**: Shell command to execute after a successful `gw start` (default: empty)
+- **post_checkout_hook**: Shell command to execute after a successful `gw checkout` (default: empty)
 
 Example `~/.gwrc`:
 ```
 # gw configuration file
 auto_cd = true
 update_iterm2_tab = false
+```
+
+#### Post Hooks
+
+You can configure shell commands to run automatically after `gw start` or `gw checkout` succeeds. Hook commands are executed via `sh -c` with the following environment variables:
+
+| Variable | Description |
+|---|---|
+| `GW_WORKTREE_PATH` | Absolute path to the created worktree |
+| `GW_BRANCH_NAME` | Branch name of the worktree |
+| `GW_REPO_NAME` | Repository name |
+| `GW_COMMAND` | The command that triggered the hook (`start` or `checkout`) |
+
+Hook failures are treated as warnings and do not block the overall command.
+
+##### Example: tmux integration
+
+Open a new tmux window for the worktree instead of changing directory in the current shell:
+
+```
+auto_cd = false
+post_start_hook = tmux new-window -c "$GW_WORKTREE_PATH" -n "$GW_BRANCH_NAME"
+post_checkout_hook = tmux new-window -c "$GW_WORKTREE_PATH" -n "$GW_BRANCH_NAME"
+```
+
+##### Example: iTerm2 new tab
+
+Open a new iTerm2 tab for the worktree on macOS. First, create a hook script:
+
+```bash
+mkdir -p ~/.gw/hooks
+cat > ~/.gw/hooks/iterm2-new-tab.sh << 'EOF'
+#!/bin/bash
+osascript <<APPLESCRIPT
+tell application "iTerm"
+    tell current window
+        create tab with default profile
+        tell current session of current tab
+            write text "cd '${GW_WORKTREE_PATH}' && clear"
+            set name to "${GW_BRANCH_NAME}"
+        end tell
+    end tell
+end tell
+APPLESCRIPT
+EOF
+chmod +x ~/.gw/hooks/iterm2-new-tab.sh
+```
+
+Then configure `.gwrc`:
+
+```
+auto_cd = false
+post_start_hook = ~/.gw/hooks/iterm2-new-tab.sh
+post_checkout_hook = ~/.gw/hooks/iterm2-new-tab.sh
+```
+
+##### Example: Custom notification
+
+Send a desktop notification after worktree creation:
+
+```
+post_start_hook = osascript -e 'display notification "Worktree ready at '"$GW_WORKTREE_PATH"'" with title "gw"'
 ```
 
 #### iTerm2 Tab Integration
@@ -225,11 +289,13 @@ Future versions will support additional configuration:
 ```
 gw/
 ├── cmd/               # Command implementations
+├── examples/hooks/    # Example hook scripts (tmux, iTerm2, etc.)
 ├── internal/
 │   ├── git/          # Git operations
 │   ├── detect/       # Package manager detection
 │   ├── ui/           # Interactive UI components
 │   ├── config/       # Configuration management
+│   ├── hook/         # Post-command hook execution
 │   └── iterm2/       # iTerm2 integration
 ├── main.go
 └── go.mod

--- a/cmd/command_checkout.go
+++ b/cmd/command_checkout.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sotarok/gw/internal/config"
+	"github.com/sotarok/gw/internal/hook"
 	"github.com/sotarok/gw/internal/iterm2"
 	"github.com/sotarok/gw/internal/spinner"
 	"github.com/sotarok/gw/internal/ui"
@@ -130,6 +131,19 @@ func (c *CheckoutCommand) Execute(branch string) error {
 	if err := c.deps.Detect.RunSetup(absolutePath); err != nil {
 		// Don't fail if setup fails, just warn
 		fmt.Fprintf(c.deps.Stderr, "%s Setup failed: %v\n", coloredWarning(), err)
+	}
+
+	// Execute post-checkout hook if configured
+	if c.config != nil && c.config.PostCheckoutHook != "" {
+		hookEnv := hook.Env{
+			WorktreePath: absolutePath,
+			BranchName:   branchName,
+			RepoName:     repoName,
+			Command:      "checkout",
+		}
+		if err := hook.Execute(c.config.PostCheckoutHook, hookEnv, c.deps.Stdout, c.deps.Stderr); err != nil {
+			fmt.Fprintf(c.deps.Stderr, "%s Post-checkout hook failed: %v\n", coloredWarning(), err)
+		}
 	}
 
 	// Show completion message

--- a/cmd/command_start.go
+++ b/cmd/command_start.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/sotarok/gw/internal/config"
+	"github.com/sotarok/gw/internal/hook"
 	"github.com/sotarok/gw/internal/iterm2"
 	"github.com/sotarok/gw/internal/spinner"
 )
@@ -105,6 +106,21 @@ func (c *StartCommand) Execute(issueNumber, baseBranch string) error {
 		// Don't fail if setup fails, just warn
 		if c.deps.Stderr != nil {
 			fmt.Fprintf(c.deps.Stderr, "%s Setup failed: %v\n", coloredWarning(), err)
+		}
+	}
+
+	// Execute post-start hook if configured
+	if c.config != nil && c.config.PostStartHook != "" {
+		branchName := issueNumber + "/impl"
+		repoNameForHook := repoName
+		hookEnv := hook.Env{
+			WorktreePath: worktreePath,
+			BranchName:   branchName,
+			RepoName:     repoNameForHook,
+			Command:      "start",
+		}
+		if err := hook.Execute(c.config.PostStartHook, hookEnv, c.deps.Stdout, c.deps.Stderr); err != nil {
+			fmt.Fprintf(c.deps.Stderr, "%s Post-start hook failed: %v\n", coloredWarning(), err)
 		}
 	}
 

--- a/cmd/command_start.go
+++ b/cmd/command_start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/sotarok/gw/internal/config"
 	"github.com/sotarok/gw/internal/hook"
@@ -112,11 +113,11 @@ func (c *StartCommand) Execute(issueNumber, baseBranch string) error {
 	// Execute post-start hook if configured
 	if c.config != nil && c.config.PostStartHook != "" {
 		branchName := issueNumber + "/impl"
-		repoNameForHook := repoName
+		absWorktreePath, _ := filepath.Abs(worktreePath)
 		hookEnv := hook.Env{
-			WorktreePath: worktreePath,
+			WorktreePath: absWorktreePath,
 			BranchName:   branchName,
-			RepoName:     repoNameForHook,
+			RepoName:     repoName,
 			Command:      "start",
 		}
 		if err := hook.Execute(c.config.PostStartHook, hookEnv, c.deps.Stdout, c.deps.Stderr); err != nil {

--- a/cmd/command_test.go
+++ b/cmd/command_test.go
@@ -3450,3 +3450,196 @@ func TestNewCleanCommand(t *testing.T) {
 		t.Error("Expected noFetch to be true")
 	}
 }
+
+func TestStartCommand_Execute_PostHook(t *testing.T) {
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	tempDir, err := os.MkdirTemp("", "gw-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	os.Chdir(tempDir)
+
+	worktreeDir, _ := os.MkdirTemp("", "gw-worktree-*")
+	defer os.RemoveAll(worktreeDir)
+
+	mockGitInstance := &mockGit{
+		isGitRepo:    true,
+		worktreePath: worktreeDir,
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	deps := &Dependencies{
+		Git:    mockGitInstance,
+		UI:     &mockUI{},
+		Detect: &mockDetect{},
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+
+	cmd := NewStartCommandWithConfig(deps, false, true, &config.Config{
+		PostStartHook: `echo "HOOK_OUTPUT:$GW_WORKTREE_PATH:$GW_COMMAND"`,
+	})
+	err = cmd.Execute("123", "main")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := stdout.String()
+	if !contains(output, "HOOK_OUTPUT:"+worktreeDir+":start") {
+		t.Errorf("Expected hook output with worktree path and command, got:\n%s", output)
+	}
+}
+
+func TestStartCommand_Execute_PostHookFailure(t *testing.T) {
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	tempDir, err := os.MkdirTemp("", "gw-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	os.Chdir(tempDir)
+
+	worktreeDir, _ := os.MkdirTemp("", "gw-worktree-*")
+	defer os.RemoveAll(worktreeDir)
+
+	mockGitInstance := &mockGit{
+		isGitRepo:    true,
+		worktreePath: worktreeDir,
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	deps := &Dependencies{
+		Git:    mockGitInstance,
+		UI:     &mockUI{},
+		Detect: &mockDetect{},
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+
+	cmd := NewStartCommandWithConfig(deps, false, true, &config.Config{
+		PostStartHook: "exit 1",
+	})
+	err = cmd.Execute("123", "main")
+
+	// Command should succeed even if hook fails
+	if err != nil {
+		t.Fatalf("Expected no error when hook fails, got: %v", err)
+	}
+	if !contains(stderr.String(), "Post-start hook failed") {
+		t.Errorf("Expected warning about hook failure in stderr, got:\n%s", stderr.String())
+	}
+	// Should still show completion message
+	if !contains(stdout.String(), "Worktree ready at:") {
+		t.Error("Expected success message even when hook fails")
+	}
+}
+
+func TestCheckoutCommand_Execute_PostHook(t *testing.T) {
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	tempDir, err := os.MkdirTemp("", "gw-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	os.Chdir(tempDir)
+
+	mockGitInstance := &mockGit{
+		isGitRepo: true,
+		envFiles:  []git.EnvFile{},
+	}
+	mockGitInstance.BranchExistsFn = func(branch string) (bool, error) {
+		return true, nil
+	}
+	mockGitInstance.CreateWorktreeFromBranchFn = func(worktreePath, sourceBranch, targetBranch string) error {
+		absolutePath, _ := filepath.Abs(worktreePath)
+		os.MkdirAll(absolutePath, 0755)
+		return nil
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	deps := &Dependencies{
+		Git:    mockGitInstance,
+		UI:     &mockUI{},
+		Detect: &mockDetect{},
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+
+	cmd := NewCheckoutCommandWithConfig(deps, false, true, &config.Config{
+		PostCheckoutHook: `echo "HOOK_OUTPUT:$GW_WORKTREE_PATH:$GW_BRANCH_NAME:$GW_COMMAND"`,
+	})
+	err = cmd.Execute("feature/test")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	output := stdout.String()
+	if !contains(output, "HOOK_OUTPUT:") {
+		t.Errorf("Expected hook output, got:\n%s", output)
+	}
+	if !contains(output, ":feature/test:checkout") {
+		t.Errorf("Expected branch name and command in hook output, got:\n%s", output)
+	}
+}
+
+func TestCheckoutCommand_Execute_PostHookFailure(t *testing.T) {
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+
+	tempDir, err := os.MkdirTemp("", "gw-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	os.Chdir(tempDir)
+
+	mockGitInstance := &mockGit{
+		isGitRepo: true,
+		envFiles:  []git.EnvFile{},
+	}
+	mockGitInstance.BranchExistsFn = func(branch string) (bool, error) {
+		return true, nil
+	}
+	mockGitInstance.CreateWorktreeFromBranchFn = func(worktreePath, sourceBranch, targetBranch string) error {
+		absolutePath, _ := filepath.Abs(worktreePath)
+		os.MkdirAll(absolutePath, 0755)
+		return nil
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	deps := &Dependencies{
+		Git:    mockGitInstance,
+		UI:     &mockUI{},
+		Detect: &mockDetect{},
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+
+	cmd := NewCheckoutCommandWithConfig(deps, false, true, &config.Config{
+		PostCheckoutHook: "exit 1",
+	})
+	err = cmd.Execute("feature/test")
+
+	if err != nil {
+		t.Fatalf("Expected no error when hook fails, got: %v", err)
+	}
+	if !contains(stderr.String(), "Post-checkout hook failed") {
+		t.Errorf("Expected warning about hook failure in stderr, got:\n%s", stderr.String())
+	}
+	if !contains(stdout.String(), "Worktree ready at:") {
+		t.Error("Expected success message even when hook fails")
+	}
+}

--- a/examples/hooks/README.md
+++ b/examples/hooks/README.md
@@ -1,0 +1,43 @@
+# Hook Examples
+
+Example hook scripts for use with `gw`'s `post_start_hook` and `post_checkout_hook` configuration.
+
+## Setup
+
+Copy the desired script to `~/.gw/hooks/` and make it executable:
+
+```bash
+mkdir -p ~/.gw/hooks
+cp examples/hooks/tmux-new-window.sh ~/.gw/hooks/
+chmod +x ~/.gw/hooks/tmux-new-window.sh
+```
+
+Then configure `~/.gwrc`:
+
+```
+auto_cd = false
+post_start_hook = ~/.gw/hooks/tmux-new-window.sh
+post_checkout_hook = ~/.gw/hooks/tmux-new-window.sh
+```
+
+## Available Scripts
+
+| Script | Description |
+|---|---|
+| `tmux-new-window.sh` | Open a new tmux window at the worktree directory |
+| `iterm2-new-tab.sh` | Open a new iTerm2 tab at the worktree directory (macOS only) |
+
+## Environment Variables
+
+Hook scripts receive these environment variables from `gw`:
+
+| Variable | Description |
+|---|---|
+| `GW_WORKTREE_PATH` | Absolute path to the created worktree |
+| `GW_BRANCH_NAME` | Branch name of the worktree |
+| `GW_REPO_NAME` | Repository name |
+| `GW_COMMAND` | The command that triggered the hook (`start` or `checkout`) |
+
+## Writing Your Own
+
+Any executable script or command can be used as a hook. Just make sure it's executable and reference it in `~/.gwrc`.

--- a/examples/hooks/iterm2-new-tab.sh
+++ b/examples/hooks/iterm2-new-tab.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Open a new iTerm2 tab and cd to the worktree directory (macOS only)
+#
+# Usage in ~/.gwrc:
+#   post_start_hook = ~/.gw/hooks/iterm2-new-tab.sh
+#   post_checkout_hook = ~/.gw/hooks/iterm2-new-tab.sh
+
+osascript <<EOF
+tell application "iTerm"
+    tell current window
+        create tab with default profile
+        tell current session of current tab
+            write text "cd '${GW_WORKTREE_PATH}' && clear"
+            set name to "${GW_BRANCH_NAME}"
+        end tell
+    end tell
+end tell
+EOF

--- a/examples/hooks/tmux-new-window.sh
+++ b/examples/hooks/tmux-new-window.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Open a new tmux window and cd to the worktree directory
+#
+# Usage in ~/.gwrc:
+#   post_start_hook = ~/.gw/hooks/tmux-new-window.sh
+#   post_checkout_hook = ~/.gw/hooks/tmux-new-window.sh
+
+tmux new-window -c "$GW_WORKTREE_PATH" -n "$GW_BRANCH_NAME"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,8 @@ const (
 	autoRemoveBranchKey   = "auto_remove_branch"
 	copyEnvsKey           = "copy_envs"
 	fetchBeforeCommandKey = "fetch_before_command"
+	postStartHookKey      = "post_start_hook"
+	postCheckoutHookKey   = "post_checkout_hook"
 )
 
 // Item represents a single configuration item with metadata
@@ -29,11 +31,13 @@ type Item struct {
 
 // Config represents the gw configuration
 type Config struct {
-	AutoCD             bool  `toml:"auto_cd"`
-	UpdateITerm2Tab    bool  `toml:"update_iterm2_tab"`
-	AutoRemoveBranch   bool  `toml:"auto_remove_branch"`
-	CopyEnvs           *bool `toml:"copy_envs"` // Pointer to distinguish between unset and false
-	FetchBeforeCommand bool  `toml:"fetch_before_command"`
+	AutoCD             bool   `toml:"auto_cd"`
+	UpdateITerm2Tab    bool   `toml:"update_iterm2_tab"`
+	AutoRemoveBranch   bool   `toml:"auto_remove_branch"`
+	CopyEnvs           *bool  `toml:"copy_envs"` // Pointer to distinguish between unset and false
+	FetchBeforeCommand bool   `toml:"fetch_before_command"`
+	PostStartHook      string `toml:"post_start_hook"`
+	PostCheckoutHook   string `toml:"post_checkout_hook"`
 }
 
 // New creates a new Config with default values
@@ -92,6 +96,10 @@ func Load(path string) (*Config, error) {
 			config.CopyEnvs = &boolValue
 		case fetchBeforeCommandKey:
 			config.FetchBeforeCommand = value == trueValue
+		case postStartHookKey:
+			config.PostStartHook = value
+		case postCheckoutHookKey:
+			config.PostCheckoutHook = value
 		}
 	}
 
@@ -117,12 +125,27 @@ func (c *Config) Save(path string) error {
 		copyEnvsStr = "# copy_envs = false  # Uncomment to set default behavior\n"
 	}
 
+	var hookLines string
+	if c.PostStartHook != "" {
+		hookLines += fmt.Sprintf("post_start_hook = %s\n", c.PostStartHook)
+	} else {
+		hookLines += "# post_start_hook =\n"
+	}
+	if c.PostCheckoutHook != "" {
+		hookLines += fmt.Sprintf("post_checkout_hook = %s\n", c.PostCheckoutHook)
+	} else {
+		hookLines += "# post_checkout_hook =\n"
+	}
+
 	content := fmt.Sprintf(`# gw configuration file
 auto_cd = %v
 update_iterm2_tab = %v
 auto_remove_branch = %v
 fetch_before_command = %v
-%s`, c.AutoCD, c.UpdateITerm2Tab, c.AutoRemoveBranch, c.FetchBeforeCommand, copyEnvsStr)
+%s
+# Hook commands executed after successful worktree operations
+# Available env vars: GW_WORKTREE_PATH, GW_BRANCH_NAME, GW_REPO_NAME, GW_COMMAND
+%s`, c.AutoCD, c.UpdateITerm2Tab, c.AutoRemoveBranch, c.FetchBeforeCommand, copyEnvsStr, hookLines)
 
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -269,7 +269,12 @@ func TestSaveConfig_DirectoryCreation(t *testing.T) {
 		"update_iterm2_tab = false\n" +
 		"auto_remove_branch = false\n" +
 		"fetch_before_command = false\n" +
-		"# copy_envs = false  # Uncomment to set default behavior\n"
+		"# copy_envs = false  # Uncomment to set default behavior\n" +
+		"\n" +
+		"# Hook commands executed after successful worktree operations\n" +
+		"# Available env vars: GW_WORKTREE_PATH, GW_BRANCH_NAME, GW_REPO_NAME, GW_COMMAND\n" +
+		"# post_start_hook =\n" +
+		"# post_checkout_hook =\n"
 	if string(content) != expectedContent {
 		t.Errorf("Expected content:\n%s\nGot:\n%s", expectedContent, string(content))
 	}
@@ -541,6 +546,8 @@ func TestSetConfigItem(t *testing.T) {
 		t.Errorf("Expected FetchBeforeCommand to be false after setting, got %v", config.FetchBeforeCommand)
 	}
 
+	// Test setting post_start_hook (not supported via SetConfigItem, it's bool-only)
+
 	// Test setting unknown key
 	err = config.SetConfigItem("unknown_key", true)
 	if err == nil {
@@ -548,5 +555,107 @@ func TestSetConfigItem(t *testing.T) {
 	}
 	if err != nil && err.Error() != "unknown configuration key: unknown_key" {
 		t.Errorf("Expected specific error message for unknown key, got: %v", err)
+	}
+}
+
+func TestLoadConfig_Hooks(t *testing.T) {
+	tests := []struct {
+		name                 string
+		configContent        string
+		expectedPostStart    string
+		expectedPostCheckout string
+	}{
+		{
+			name: "hooks not set",
+			configContent: `auto_cd = true
+`,
+			expectedPostStart:    "",
+			expectedPostCheckout: "",
+		},
+		{
+			name: "post_start_hook set",
+			configContent: `auto_cd = true
+post_start_hook = tmux new-window -c "$GW_WORKTREE_PATH"
+`,
+			expectedPostStart:    `tmux new-window -c "$GW_WORKTREE_PATH"`,
+			expectedPostCheckout: "",
+		},
+		{
+			name: "both hooks set",
+			configContent: `auto_cd = false
+post_start_hook = tmux new-window -c "$GW_WORKTREE_PATH" -n "$GW_BRANCH_NAME"
+post_checkout_hook = tmux new-window -c "$GW_WORKTREE_PATH" -n "$GW_BRANCH_NAME"
+`,
+			expectedPostStart:    `tmux new-window -c "$GW_WORKTREE_PATH" -n "$GW_BRANCH_NAME"`,
+			expectedPostCheckout: `tmux new-window -c "$GW_WORKTREE_PATH" -n "$GW_BRANCH_NAME"`,
+		},
+		{
+			name: "hook with equals sign in value",
+			configContent: `post_start_hook = env GW_EXTRA=1 my-script
+`,
+			expectedPostStart: "env GW_EXTRA=1 my-script",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			configPath := filepath.Join(tempDir, ".gwrc")
+
+			if err := os.WriteFile(configPath, []byte(tt.configContent), 0644); err != nil {
+				t.Fatalf("Failed to write test config: %v", err)
+			}
+
+			config, err := Load(configPath)
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+
+			if config.PostStartHook != tt.expectedPostStart {
+				t.Errorf("Expected PostStartHook %q, got %q", tt.expectedPostStart, config.PostStartHook)
+			}
+			if config.PostCheckoutHook != tt.expectedPostCheckout {
+				t.Errorf("Expected PostCheckoutHook %q, got %q", tt.expectedPostCheckout, config.PostCheckoutHook)
+			}
+		})
+	}
+}
+
+func TestSaveConfig_Hooks(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, ".gwrc")
+
+	cfg := &Config{
+		AutoCD:           true,
+		PostStartHook:    `tmux new-window -c "$GW_WORKTREE_PATH"`,
+		PostCheckoutHook: `tmux new-window -c "$GW_WORKTREE_PATH"`,
+	}
+
+	err := cfg.Save(configPath)
+	if err != nil {
+		t.Fatalf("Failed to save config: %v", err)
+	}
+
+	// Reload and verify
+	loaded, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load saved config: %v", err)
+	}
+
+	if loaded.PostStartHook != cfg.PostStartHook {
+		t.Errorf("Expected PostStartHook %q, got %q", cfg.PostStartHook, loaded.PostStartHook)
+	}
+	if loaded.PostCheckoutHook != cfg.PostCheckoutHook {
+		t.Errorf("Expected PostCheckoutHook %q, got %q", cfg.PostCheckoutHook, loaded.PostCheckoutHook)
+	}
+}
+
+func TestNewConfig_HooksEmpty(t *testing.T) {
+	cfg := New()
+	if cfg.PostStartHook != "" {
+		t.Errorf("Expected PostStartHook to be empty by default, got %q", cfg.PostStartHook)
+	}
+	if cfg.PostCheckoutHook != "" {
+		t.Errorf("Expected PostCheckoutHook to be empty by default, got %q", cfg.PostCheckoutHook)
 	}
 }

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,0 +1,45 @@
+package hook
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// Env holds environment variables passed to hook commands
+type Env struct {
+	WorktreePath string
+	BranchName   string
+	RepoName     string
+	Command      string // "start", "checkout", or "end"
+}
+
+// Execute runs a hook command with the given environment variables.
+// If hookCmd is empty, it does nothing and returns nil.
+// The hook command is executed via "sh -c" with GW_* environment variables.
+func Execute(hookCmd string, env Env, stdout, stderr io.Writer) error {
+	if hookCmd == "" {
+		return nil
+	}
+
+	cmd := exec.Command("sh", "-c", hookCmd)
+	cmd.Env = append(os.Environ(), envToSlice(env)...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("hook command failed: %w", err)
+	}
+
+	return nil
+}
+
+func envToSlice(env Env) []string {
+	return []string{
+		"GW_WORKTREE_PATH=" + env.WorktreePath,
+		"GW_BRANCH_NAME=" + env.BranchName,
+		"GW_REPO_NAME=" + env.RepoName,
+		"GW_COMMAND=" + env.Command,
+	}
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -12,7 +12,7 @@ type Env struct {
 	WorktreePath string
 	BranchName   string
 	RepoName     string
-	Command      string // "start", "checkout", or "end"
+	Command      string // "start" or "checkout"
 }
 
 // Execute runs a hook command with the given environment variables.

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,0 +1,144 @@
+package hook
+
+import (
+	"bytes"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestExecute_EmptyCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := Execute("", Env{}, &stdout, &stderr)
+	if err != nil {
+		t.Errorf("Expected no error for empty command, got: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("Expected no stdout output, got: %s", stdout.String())
+	}
+}
+
+const osWindows = "windows"
+
+func TestExecute_SimpleCommand(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("Skipping on Windows")
+	}
+
+	var stdout, stderr bytes.Buffer
+	env := Env{
+		WorktreePath: "/tmp/test-worktree",
+		BranchName:   "123/impl",
+		RepoName:     "my-repo",
+		Command:      "start",
+	}
+
+	err := Execute("echo $GW_WORKTREE_PATH", env, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	expected := "/tmp/test-worktree\n"
+	if stdout.String() != expected {
+		t.Errorf("Expected stdout %q, got %q", expected, stdout.String())
+	}
+}
+
+func TestExecute_AllEnvVars(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("Skipping on Windows")
+	}
+
+	var stdout, stderr bytes.Buffer
+	env := Env{
+		WorktreePath: "/path/to/worktree",
+		BranchName:   "feature/test",
+		RepoName:     "test-repo",
+		Command:      "checkout",
+	}
+
+	err := Execute("echo $GW_WORKTREE_PATH:$GW_BRANCH_NAME:$GW_REPO_NAME:$GW_COMMAND", env, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	expected := "/path/to/worktree:feature/test:test-repo:checkout\n"
+	if stdout.String() != expected {
+		t.Errorf("Expected stdout %q, got %q", expected, stdout.String())
+	}
+}
+
+func TestExecute_FailingCommand(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("Skipping on Windows")
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := Execute("exit 1", Env{}, &stdout, &stderr)
+	if err == nil {
+		t.Error("Expected error for failing command, got nil")
+	}
+}
+
+func TestExecute_StderrOutput(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("Skipping on Windows")
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := Execute("echo error >&2", Env{}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if stderr.String() != "error\n" {
+		t.Errorf("Expected stderr %q, got %q", "error\n", stderr.String())
+	}
+}
+
+func TestExecute_InheritsParentEnv(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("Skipping on Windows")
+	}
+
+	os.Setenv("GW_TEST_PARENT_VAR", "hello")
+	defer os.Unsetenv("GW_TEST_PARENT_VAR")
+
+	var stdout, stderr bytes.Buffer
+	err := Execute("echo $GW_TEST_PARENT_VAR", Env{}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if stdout.String() != "hello\n" {
+		t.Errorf("Expected stdout %q, got %q", "hello\n", stdout.String())
+	}
+}
+
+func TestEnvToSlice(t *testing.T) {
+	env := Env{
+		WorktreePath: "/path/to/worktree",
+		BranchName:   "123/impl",
+		RepoName:     "my-repo",
+		Command:      "start",
+	}
+
+	slice := envToSlice(env)
+
+	expected := []string{
+		"GW_WORKTREE_PATH=/path/to/worktree",
+		"GW_BRANCH_NAME=123/impl",
+		"GW_REPO_NAME=my-repo",
+		"GW_COMMAND=start",
+	}
+
+	if len(slice) != len(expected) {
+		t.Fatalf("Expected %d env vars, got %d", len(expected), len(slice))
+	}
+
+	for i, exp := range expected {
+		if slice[i] != exp {
+			t.Errorf("Expected env[%d] = %q, got %q", i, exp, slice[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add configurable `post_start_hook` and `post_checkout_hook` options to `.gwrc`
- Hook commands are executed via `sh -c` with environment variables (`GW_WORKTREE_PATH`, `GW_BRANCH_NAME`, `GW_REPO_NAME`, `GW_COMMAND`)
- Enables integration with tmux, iTerm2, or any custom workflow without hardcoding terminal-specific behavior
- Include example hook scripts in `examples/hooks/` for tmux and iTerm2

Inspired by #20 (thanks @pnikonowicz).

Closes #20

## Test plan

- [x] `make check` passes (lint + all tests)
- [x] Manual test: `post_start_hook = echo ...` fires after `gw start`
- [x] Manual test: tmux new-window hook works
- [x] Manual test: iTerm2 new-tab hook works
- [x] Hook failure does not block command execution
- [x] Backward compatible: no hooks configured = existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)